### PR TITLE
Add hidden_indexable_content field to UTIAC decisions

### DIFF
--- a/app/exporters/formatters/utiac_decision_indexable_formatter.rb
+++ b/app/exporters/formatters/utiac_decision_indexable_formatter.rb
@@ -13,6 +13,7 @@ private
       decision_reported: entity.decision_reported,
       judges: entity.judges,
       promulgation_date: entity.promulgation_date,
+      indexable_content: entity.hidden_indexable_content || entity.body
     }
   end
 

--- a/app/models/utiac_decision.rb
+++ b/app/models/utiac_decision.rb
@@ -6,6 +6,7 @@ class UtiacDecision < DocumentMetadataDecorator
     :country_guidance,
     :decision_reported,
     :judges,
+    :hidden_indexable_content,
     :promulgation_date,
   ]
 end

--- a/app/view_adapters/utiac_decision_view_adapter.rb
+++ b/app/view_adapters/utiac_decision_view_adapter.rb
@@ -5,6 +5,7 @@ class UtiacDecisionViewAdapter < TribunalDecisionViewAdapter
     :country_guidance,
     :decision_reported,
     :judges,
+    :hidden_indexable_content,
     :promulgation_date,
   ]
 

--- a/app/views/utiac_decisions/_form.html.erb
+++ b/app/views/utiac_decisions/_form.html.erb
@@ -2,13 +2,14 @@
   <%= form_for document do |f| %>
     <%= render partial: "shared/form_errors", locals: { object: document } %>
     <%= render partial: "shared/form_fields", locals: { f: f } %>
+    <%= f.text_area :hidden_indexable_content, class: 'form-control' %>
+
     <%= render partial: "shared/form_preview" %>
 
     <%= f.select :country_guidance, f.object.facet_options(:country_guidance), {}, { class: 'form-control' } %>
     <%= f.select :country, f.object.facet_options(:country), {}, { class: 'form-control' } %>
     <%= f.select :decision_reported, f.object.facet_options(:decision_reported), {}, { class: 'form-control' } %>
     <%= f.select :judges, f.object.facet_options(:judges), {}, { class: 'select2', multiple: true, data: {placeholder: 'Select judges'} } %>
-
 
     <%= f.text_field :promulgation_date, placeholder: '2015-04-23', class: 'form-control' %>
 

--- a/spec/exporters/formatters/utiac_decision_indexable_formatter_spec.rb
+++ b/spec/exporters/formatters/utiac_decision_indexable_formatter_spec.rb
@@ -13,11 +13,13 @@ RSpec.describe UtiacDecisionIndexableFormatter do
       decision_reported: double,
       judges: double,
       minor_update?: false,
+      hidden_indexable_content: double,
       promulgation_date: double,
       slug: double,
       summary: double,
       title: double,
       updated_at: double,
+      public_updated_at: nil
     )
   }
 
@@ -28,4 +30,20 @@ RSpec.describe UtiacDecisionIndexableFormatter do
   it "should have a type of utiac_decision" do
     expect(formatter.type).to eq("utiac_decision")
   end
+
+  context "without hidden_indexable_content" do
+
+    it "should have body as its indexable_content" do
+      allow(document).to receive(:hidden_indexable_content).and_return(nil)
+      expect(formatter.indexable_attributes[:indexable_content]).to eq(document.body)
+    end
+  end
+
+  context "with hidden_indexable_content" do
+
+    it "should have hidden_indexable_content as its indexable_content" do
+      expect(formatter.indexable_attributes[:indexable_content]).to eq(document.hidden_indexable_content)
+    end
+  end
+
 end


### PR DESCRIPTION
Demonstrate one approach to indexing decision content for search without that content being displayed in the frontend search results.

Further work could be done to extract this content from doc formatted decisions, and populate hidden_indexable_content programmatically.
