### PR TITLE
Change generator to store facet values directly in rummager

### DIFF
--- a/lib/generators/finder/finder_generator.rb
+++ b/lib/generators/finder/finder_generator.rb
@@ -356,17 +356,9 @@ INSERT
   end
 
   def create_schema_in_rummager
-    fields = @rummager_plus_name_attributes
-
     schema_file = "../rummager/config/schema/document_types/#{name.underscore}.json"
-    if File.exist?(schema_file)
-      existing_schema = JSON.parse File.open(schema_file).read
-      if existing_schema['fields'].sort == @rummager_plus_name_attributes.sort
-        fields = existing_schema['fields']
-      end
-    end
 
-    hash = { fields: fields }
+    hash = { fields: @rummager_plus_name_attributes.sort }
 
     create_file schema_file, "#{JSON.pretty_generate(hash)}\n"
   end
@@ -386,7 +378,7 @@ INSERT
       end
       (@rummager_plus_name_attributes - @rummager_attributes).each do |attribute|
         unless existing_definitions.has_key?(attribute)
-          new_attributes[attribute] = { type: @rummager_plus_name_types[attribute] }
+          new_attributes[attribute] = { type: "searchable_#{@rummager_plus_name_types[attribute]}" }
         end
       end
       definitions_json = ",\n  " + JSON.pretty_generate(new_attributes).sub("{", "").chomp("}").strip

--- a/lib/generators/finder/templates/indexable_formatter.rb.erb
+++ b/lib/generators/finder/templates/indexable_formatter.rb.erb
@@ -8,7 +8,8 @@ class <%= class_name %>IndexableFormatter < AbstractSpecialistDocumentIndexableF
 private
   def extra_attributes
     {<% @rummager_attributes.each do |attribute| %>
-      <%= attribute %>: entity.<%= attribute %>,<% end %>
+      <%= attribute %>: entity.<%= attribute %>,<% if @allowed_values.has_key?(attribute)%>
+      <%= attribute %>_name: expand_value(:<%= attribute %>),<% end %><% end %>
 <% if options[:hidden_indexable_content] %>      indexable_content: entity.hidden_indexable_content || entity.body
 <% end %>    }
   end

--- a/lib/generators/finder/templates/indexable_formatter_spec.rb.erb
+++ b/lib/generators/finder/templates/indexable_formatter_spec.rb.erb
@@ -14,12 +14,14 @@ RSpec.describe <%= class_name %>IndexableFormatter do
       updated_at: double,
       minor_update?: false,
       public_updated_at: double,
-<% @document_attributes.each do |attribute| %>
-      <%= attribute %>: double,<% end %>
+<% @document_attributes.each_with_index do |attribute, index| %>
+      <%= attribute %>: <% if @rummager_types[index] && @rummager_types[index][/identifiers/] %>[double]<% else %>double<% end %>,<% end %>
     )
   }
 
   subject(:formatter) { <%= class_name %>IndexableFormatter.new(document) }
+
+  include_context "schema available"
 
   it_should_behave_like "a specialist document indexable formatter"
 


### PR DESCRIPTION
This approach means we no longer need to set allowed_values in the rummager schema configuration. In finder frontend metadata labels now come directly from rummager as separate _name fields.
