### PR TITLE
Make body and hidden_indexable_content indexable in generated finder

### DIFF
--- a/lib/generators/finder/templates/indexable_formatter.rb.erb
+++ b/lib/generators/finder/templates/indexable_formatter.rb.erb
@@ -10,7 +10,7 @@ private
     {<% @rummager_attributes.each do |attribute| %>
       <%= attribute %>: entity.<%= attribute %>,<% if @allowed_values.has_key?(attribute)%>
       <%= attribute %>_name: expand_value(:<%= attribute %>),<% end %><% end %>
-<% if options[:hidden_indexable_content] %>      indexable_content: entity.hidden_indexable_content || entity.body
+<% if options[:hidden_indexable_content] %>      indexable_content: "#{entity.hidden_indexable_content}\n#{entity.body}".strip
 <% end %>    }
   end
 

--- a/lib/generators/finder/templates/indexable_formatter_spec.rb.erb
+++ b/lib/generators/finder/templates/indexable_formatter_spec.rb.erb
@@ -7,7 +7,7 @@ RSpec.describe <%= class_name %>IndexableFormatter do
   let(:document) {
     double(
       :<%= name.underscore%>,
-      body: double("body"),
+      body: double,
       slug: "/slug",
       summary: double,
       title: double,
@@ -31,14 +31,20 @@ RSpec.describe <%= class_name %>IndexableFormatter do
 
   context "without hidden_indexable_content" do
     it "should have body as its indexable_content" do
+      allow(document).to receive(:body).and_return("body text")
       allow(document).to receive(:hidden_indexable_content).and_return(nil)
-      expect(formatter.indexable_attributes[:indexable_content]).to eq(document.body)
+
+      expect(formatter.indexable_attributes[:indexable_content]).to eq("body text")
     end
   end
 
   context "with hidden_indexable_content" do
     it "should have hidden_indexable_content as its indexable_content" do
-      expect(formatter.indexable_attributes[:indexable_content]).to eq(document.hidden_indexable_content)
+      allow(document).to receive(:body).and_return("body text")
+      allow(document).to receive(:hidden_indexable_content).and_return("hidden indexable content text")
+
+      indexable = formatter.indexable_attributes[:indexable_content]
+      expect(indexable).to eq("hidden indexable content text\nbody text")
     end
   end
 <% end %>


### PR DESCRIPTION
As recommended by search team members here: https://github.com/ministryofjustice/specialist-publisher/commit/512a73301be1f9909573b847e23222a4bcd126cd#commitcomment-12928833

"There's little harm if there's duplication between `body` and `indexable_content_indexable`, and there's
definite benefit to making sure any text we have available is searchable."
